### PR TITLE
Use tsl/ordered_map instead of std::map #22

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/ngx_url_parser"]
 	path = deps/ngx_url_parser
 	url = https://github.com/DreamLab/ngx_url_parser.git
+[submodule "deps/ordered-map"]
+	path = deps/ordered-map
+	url = https://github.com/Tessil/ordered-map

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
             ],
             "include_dirs": [
                 "<(module_root_dir)/build/ngx_url_parser/include/ngx_url_parser",
+                "<(module_root_dir)/deps/ordered-map/",
                 "<!(node -e \"require('nan')\")"
 
             ],

--- a/package.json
+++ b/package.json
@@ -1,20 +1,25 @@
 {
     "name": "uriparser",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "description": "Fastest uriparser, written in C",
-    "keywords": ["uriparser", "uri", "parser", "url"],
+    "keywords": [
+        "uriparser",
+        "uri",
+        "parser",
+        "url"
+    ],
     "contributors": [
         "Jakub Lekstan <kuebzky@gmail.com>",
         "Marcin Kaciuba <marcin.kaciuba@gmail.com>"
     ],
     "dependencies": {
-        "nan": "~2.9.2"
+        "nan": "^2.9.2"
     },
     "devDependencies": {
-      "jasmine-node": "1.14.5"
+        "jasmine-node": "1.14.5"
     },
     "scripts": {
-      "test": "jasmine-node tests/*"
+        "test": "jasmine-node tests/*"
     },
     "main": "./bin/uriparser.node",
     "repository": {
@@ -22,6 +27,6 @@
         "url": "https://github.com/DreamLab/uriparser.git"
     },
     "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 8.0.0"
     }
 }

--- a/src/node-uriparser.cc
+++ b/src/node-uriparser.cc
@@ -96,7 +96,7 @@ NAN_METHOD(parse) {
     v8::Local<v8::Object> data = Nan::New<v8::Object>();
 
     Url uri;
-    NgxParser parser{*url};
+    NgxParser parser(*url);
 
     if (parser.status != Parser::OK) {
         Nan::ThrowError("Unable to parse given url");


### PR DESCRIPTION
Average from 3 runs. Tested on node 9.7.1


benchmark | avg old [ms] | avg new [ms] | % diff [100 - old/new * 100 %]
-- | -- | -- | --
simple url | 2274.382 | 2031.633 | -11.94846707
complex url | 11664.32533 | 10741.85067 | -8.587669809
short query | 8876.287667 | 7680.794333 | -15.5647096
long query | 27470.93667 | 20070.11033 | -36.87486621

